### PR TITLE
Add enum values for quality

### DIFF
--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -1,3 +1,5 @@
 class Idea < ApplicationRecord
 
+  enum quality: %w(Swill Plausible Genius)
+
 end

--- a/app/views/ideas/index.html.erb
+++ b/app/views/ideas/index.html.erb
@@ -1,8 +1,9 @@
 <div class="container">
 <% @ideas.each do |idea| %>
 <div class="row">
-  <%= idea.title %>
-  <%= idea.body %>
+  Title: <%= idea.title %>,
+  Body: <%= idea.body %>,
+  Quality: <%= idea.quality %><br /><br />
 </div>
 <% end %>
   <div class="row">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,11 +6,11 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-Idea.create(title: "Genius Title 1", body: "Genius Body 1", quality: 2)
-Idea.create(title: "Genius Title 2", body: "Genius Body 2", quality: 2)
+Idea.create(title: "Genius-Title-1", body: "Genius-Body-1", quality: 2)
+Idea.create(title: "Genius-Title-2", body: "Genius-Body-2", quality: 2)
 
-Idea.create(title: "Plausible Title 1", body: "Plausible Body 1", quality: 1)
-Idea.create(title: "Plausible Title 2", body: "Plausible Body 2", quality: 1)
+Idea.create(title: "Plausible-Title-1", body: "Plausible-Body-1", quality: 1)
+Idea.create(title: "Plausible-Title-2", body: "Plausible-Body-2", quality: 1)
 
-Idea.create(title: "Swill Title 1", body: "Swill Body 1")
-Idea.create(title: "Swill Title 2", body: "Swill Body 2")
+Idea.create(title: "Swill-Title-1", body: "Swill-Body-1")
+Idea.create(title: "Swill-Title-2", body: "Swill-Body-2")

--- a/spec/controllers/api/v1/returns_ideas_ordered_by_created_at_spec.rb
+++ b/spec/controllers/api/v1/returns_ideas_ordered_by_created_at_spec.rb
@@ -7,15 +7,16 @@ RSpec.describe Api::V1::IdeasController, type: :controller do
     it 'returns a list of ideas sorted by created_at' do
       ideas = [create(:idea)]
       sleep 1
-      ideas << create(:idea)
+      ideas << create(:idea, quality: 1)
       sleep 1
-      ideas << create(:idea)
+      ideas << create(:idea, quality: 2)
 
       get :index, params: {format: :json}
       result = JSON.parse(response.body, symbolize_names: true)
       ideas.reverse.each_with_index do |idea, x|
         expect(idea.title).to eq(result[x][:title])
         expect(idea.body).to eq(result[x][:body])
+        expect(idea.quality).to eq(result[x][:quality])
       end
     end
   end


### PR DESCRIPTION
Add enum strings for the 'quality' property of the Idea model. Modify the seed file to use hyphenated strings for readability. Modify the test to check for qualities. 

Closes #13 
