### PR TITLE
Create API endpoint to increment the quality

### DIFF
--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -12,6 +12,11 @@ class Api::V1::IdeasController < ApplicationController
     @result = Idea.delete(params[:id])
   end
 
+  def increment
+    idea = Idea.find(params[:id])
+    idea.increment
+  end
+
   private
   def idea_params
     params.require(:idea).permit(:title, :body)

--- a/app/models/idea.rb
+++ b/app/models/idea.rb
@@ -2,4 +2,12 @@ class Idea < ApplicationRecord
 
   enum quality: %w(Swill Plausible Genius)
 
+  def increment
+    if quality == "Swill"
+      update_attribute('quality', 'Plausible')
+    elsif quality == "Plausible"
+      update_attribute('quality', 'Genius')
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
       resources :ideas, only: [:index, :create, :destroy]
+      post 'increment', to: 'ideas#increment'
     end
   end
 end

--- a/spec/controllers/api/v1/test_api.rb
+++ b/spec/controllers/api/v1/test_api.rb
@@ -54,4 +54,41 @@ RSpec.describe Api::V1::IdeasController, type: :controller do
       expect(Idea.count).to eq(0)
     end
   end
+
+  describe "Increment quality" do
+    it 'accepts a database id and increments the quality from swill to Plausible' do
+      idea = create(:idea)
+      expect(idea.quality).to eq("Swill")
+
+      post :increment, params: {id: idea.id, format: :json}
+      expect(Idea.last.id).to eq(idea.id)
+      expect(Idea.last.quality).to eq("Plausible")
+    end
+
+    it 'accepts a database id and increments the quality from Plausible to Genius' do
+      idea = create(:idea)
+      expect(idea.quality).to eq("Swill")
+
+      post :increment, params: {id: idea.id, format: :json}
+
+      post :increment, params: {id: idea.id, format: :json}
+      expect(Idea.last.id).to eq(idea.id)
+      expect(Idea.last.quality).to eq("Genius")
+    end
+
+    it 'accepts a database id does not change when quality is Genius' do
+      idea = create(:idea)
+      expect(idea.quality).to eq("Swill")
+
+      post :increment, params: {id: idea.id, format: :json}
+
+      post :increment, params: {id: idea.id, format: :json}
+      expect(Idea.last.id).to eq(idea.id)
+      expect(Idea.last.quality).to eq("Genius")
+
+      post :increment, params: {id: idea.id, format: :json}
+      expect(Idea.last.id).to eq(idea.id)
+      expect(Idea.last.quality).to eq("Genius")
+    end
+  end
 end


### PR DESCRIPTION
Add an endpoint to increment quality for ideas lower than 'genius'.

closes #34 
