### PR TITLE
Add edit function to Title and Body text

### DIFF
--- a/app/assets/javascripts/ideas.js
+++ b/app/assets/javascripts/ideas.js
@@ -8,6 +8,12 @@ $(document).ready(function(){
   $("#ideasDiv").on('click', ".thumbs-up-button", incrementQuality);
   $("#ideasDiv").on('click', ".thumbs-down-button", decrementQuality);
 
+  $("#ideasDiv").on('focusout', ".searchableTitle", changeTitle);
+  $("#ideasDiv").on('keydown', ".searchableTitle", catchCarriageReturn);
+  
+  $("#ideasDiv").on('focusout', ".searchableBody", changeTitle);
+  $("#ideasDiv").on('keydown', ".searchableBody", catchCarriageReturn);
+
 });
 
 
@@ -98,4 +104,28 @@ function runSearch(){
 
 function unHideRows(){
   $('.row').removeClass("hidden")
+};
+
+function changeTitle(){
+  console.log("changeTitle fired");
+  if (this.classList[0] === "searchableTitle") {
+    attributeToChange = "title";
+  } else if (this.classList[0] === "searchableBody") {
+    attributeToChange = "body";
+  }
+  $.ajax({
+    method: "POST",
+    url: "/api/v1/update/" + this.parentElement.id,
+    dataType: "JSON",
+    data: {idea: {attribute: attributeToChange, value: this.innerText}},
+    success: fetchIdeas
+  })
+
+};
+
+function catchCarriageReturn(e){
+  if (e.key === "Enter") {
+    e.preventDefault();
+    $(this).blur();
+  }
 };

--- a/app/controllers/api/v1/ideas_controller.rb
+++ b/app/controllers/api/v1/ideas_controller.rb
@@ -22,8 +22,19 @@ class Api::V1::IdeasController < ApplicationController
     idea.decrement
   end
 
+  def update
+    idea = Idea.find(params[:id])
+    idea.update_attribute(update_params[:attribute], update_params[:value])
+  end
+
   private
   def idea_params
     params.require(:idea).permit(:title, :body)
   end
+
+  def update_params
+    params.require(:idea).permit(:attribute, :value)
+  end
+
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       resources :ideas, only: [:index, :create, :destroy]
       post 'increment/:id', to: 'ideas#increment'
       post 'decrement/:id', to: 'ideas#decrement'
+      post 'update/:id', to: 'ideas#update'
     end
   end
 end


### PR DESCRIPTION
Add function for Title and Body text to be editable. Changes persist to the Database when the text field loses focus. Pressing Enter causes the element to lose focus.
- Add API endpoint for update
- Add `update` action on API controller
- Add Javascript to handle the edit and trigger the update

Closes #43 
